### PR TITLE
Update readme and scp event

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Control    | CSP/AWS | HOST/OS | App/DB | How is it implemented?
 ---------- | ------- | ------- | ------ | ----------------------
 [AC-2(g)](https://nvd.nist.gov/800-53/Rev4/control/AC-2) | ╳ | | | Employs the use of a CloudWatch Event Rule to continuously monitor and alert on changes to AWS IAM configurations.
 [AC-2(4)](https://nvd.nist.gov/800-53/Rev4/control/AC-2#enhancement-4) | ╳ | | | Employs the use of a CloudWatch Event Rule to continuously monitor and alert on changes to AWS IAM configurations.
+[SI-5(b)](https://nvd.nist.gov/800-53/Rev4/control/SI-5) | ╳ | | | Employs the use of a CloudWatch Event Rule to continuously monitor and alert on changes to various resource configurations.
 
 [top](#top)
 

--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ GRACE Alerting provides basic CloudWatch Event Rules and Log Metric Filters that
 - [Terraform Module Outputs](#terraform-module-outputs)
 
 ## Security Compliance
-
+The GRACE Alerting subcomponent provides various levels of coverage for several [NIST Special Publication 800-53 (Rev. 4) Security Controls](https://nvd.nist.gov/800-53/Rev4/impact/moderate).  These security controls are designated for [FIPS 199 Moderate Impact Systems](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.199.pdf). Additional information regarding the implementation method utilized can be found within the [GRACE Component Control Coverage Repository](https://github.com/GSA/grace-ssp/blob/master/README.md).
 **Component ATO status:** draft
 
 **Relevant controls:**
 
-| Control    | CSP/AWS | HOST/OS | App/DB | How is it implemented? |
-| ---------- | ------- | ------- | ------ | ---------------------- |
-
+Control    | CSP/AWS | HOST/OS | App/DB | How is it implemented?
+---------- | ------- | ------- | ------ | ----------------------
+[AC-2(g)](https://nvd.nist.gov/800-53/Rev4/control/AC-2) | ╳ | | | Employs the use of a CloudWatch Event Rule to continuously monitor and alert on changes to AWS IAM configurations.
+[AC-2(4)](https://nvd.nist.gov/800-53/Rev4/control/AC-2#enhancement-4) | ╳ | | | Employs the use of a CloudWatch Event Rule to continuously monitor and alert on changes to AWS IAM configurations.
 
 [top](#top)
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ GRACE Alerting provides basic CloudWatch Event Rules and Log Metric Filters that
 
 | Rule Name | Description |
 | --------- | ----------- |
-| scp_changes | Alert on Attach, Detach, Update, Disable, and Enable Service Control Policies and Types |
+| scp_changes | This event rule is only useful when your account is also the AWS Organization's Master Account.  Alert on Attach, Detach, Update, Disable, and Enable Service Control Policies and Types |
 | s3_bucket_changes | Alert on S3 Bucket access and permission related changes |
 | config_compliance_changes | Alert on changes to AWS Config Rule compliance states |
 | cloudtrail_configuration_changes | Alert on changes to CloudTrail Logging Configuration |
@@ -94,7 +94,7 @@ module "alerting" {
 | alert_on_console_login_without_mfa | Alert when a user signs into the AWS Console without using multi-factor authentication | bool | true | no |
 | console_login_without_mfa_period | Duration in seconds to capture events before resetting the count | number | 300 | no |
 | console_login_without_mfa_threshold | Number of captured events required before triggering the alarm | number | 1 | no |
-| alert_on_scp_changes | Alert on Attach, Detach, Update, Disable, and Enable Service Control Policies and Types | bool | true | no |
+| alert_on_scp_changes | Alert on Attach, Detach, Update, Disable, and Enable Service Control Policies and Types | bool | false | no |
 | alert_on_s3_bucket_changes | Alert on S3 Bucket access and permission related changes | bool | true | no |
 | alert_on_config_compliance_changes | Alert on changes to AWS Config Rule compliance states | bool | true | no |
 | alert_on_cloudtrail_configuration_changes | Alert on changes to CloudTrail Logging Configuration | bool | true | no |

--- a/variables.tf
+++ b/variables.tf
@@ -82,8 +82,8 @@ variable "console_login_without_mfa_threshold" {
 
 variable "alert_on_scp_changes" {
   type        = bool
-  description = "(optional) Alert on Attach, Detach, Update, Disable, and Enable Service Control Policies and Types"
-  default     = true
+  description = "(optional) This event rule is only useful when your account is also the AWS Organization's Master Account.  Alert on Attach, Detach, Update, Disable, and Enable Service Control Policies and Types"
+  default     = false
 }
 
 variable "alert_on_s3_bucket_changes" {


### PR DESCRIPTION
Removed some of the initial security controls thought to be related to grace-alerting. 
The SI-4 control and sub-controls were removed from the scope because they are more related to SIEM monitoring solutions and malicious code identification.