### PR TITLE
Use ${path.module} when imported as a module

### DIFF
--- a/sns.tf
+++ b/sns.tf
@@ -4,5 +4,5 @@
 
 resource "aws_cloudformation_stack" "alerting_topic" {
   name          = "alerting-topic"
-  template_body = templatefile("files/alerting-topic.json", { recipient : var.recipient })
+  template_body = templatefile("${path.module}/files/alerting-topic.json", { recipient : var.recipient })
 }


### PR DESCRIPTION
path error occurs when using as an imported module