### PR TITLE
Update to 13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - checkout
       - run:
           name: Install tfsec
-          command: env GO111MODULE=on go get -u github.com/liamg/tfsec/cmd/tfsec
+          command: env GO111MODULE=on go get -u github.com/tfsec/tfsec/cmd/tfsec
       - run:
           name: Terraform static code analysis with tfsec
           command: tfsec

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: if [[ -n "$(terraform fmt -write=false)" ]]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi
       - run:
           name: Install tflint
-          command: curl -L -o /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v0.14.0/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
+          command: curl -L -o /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v0.24.1/tflint_linux_amd64.zip && unzip /tmp/tflint.zip -d /usr/local/bin
       - run:
           name: Check Terraform configurations with tflint
           command: find . -name ".terraform" -prune -o -type f -name "*.tf" -exec dirname {} \;|sort -u | while read m; do (cd "$m" && tflint && echo "√ $m") || exit 1 ; done

--- a/events.tf
+++ b/events.tf
@@ -48,7 +48,6 @@ resource "aws_cloudwatch_event_target" "scp_changes" {
       "SourceIP"        = "$.detail.sourceIPAddress"
       "UserAgent"       = "$.detail.userAgent"
       "EventSource"     = "$.detail.eventSource"
-      "AWSRegion"       = "$.detail.awsRegion"
       "EventName"       = "$.detail.eventName"
       "EventParameters" = "$.detail.requestParameters[*]"
     }
@@ -120,7 +119,6 @@ resource "aws_cloudwatch_event_target" "s3_bucket_changes" {
       "SourceIP"        = "$.detail.sourceIPAddress"
       "UserAgent"       = "$.detail.userAgent"
       "EventSource"     = "$.detail.eventSource"
-      "AWSRegion"       = "$.detail.awsRegion"
       "EventName"       = "$.detail.eventName"
       "EventParameters" = "$.detail.requestParameters[*]"
     }
@@ -171,7 +169,6 @@ resource "aws_cloudwatch_event_target" "config_compliance_changes" {
     input_paths = {
       "EventTime"           = "$.time"
       "EventType"           = "$.detail-type"
-      "AWSRegion"           = "$.detail.awsRegion"
       "AWSAccount"          = "$.detail.awsAccountId"
       "ConfigRuleName"      = "$.detail.newEvaluationResult.evaluationResultIdentifier.evaluationResultQualifier.configRuleName"
       "ResourceType"        = "$.detail.newEvaluationResult.evaluationResultIdentifier.evaluationResultQualifier.resourceType"
@@ -244,7 +241,6 @@ resource "aws_cloudwatch_event_target" "sns_cloudtrail_configuration_changes" {
       "SourceIP"        = "$.detail.sourceIPAddress"
       "UserAgent"       = "$.detail.userAgent"
       "EventSource"     = "$.detail.eventSource"
-      "AWSRegion"       = "$.detail.awsRegion"
       "EventName"       = "$.detail.eventName"
       "EventParameters" = "$.detail.requestParameters[*]"
     }
@@ -315,7 +311,6 @@ resource "aws_cloudwatch_event_target" "sns_config_configuration_changes" {
       "SourceIP"        = "$.detail.sourceIPAddress"
       "UserAgent"       = "$.detail.userAgent"
       "EventSource"     = "$.detail.eventSource"
-      "AWSRegion"       = "$.detail.awsRegion"
       "EventName"       = "$.detail.eventName"
       "EventParameters" = "$.detail.requestParameters[*]"
     }
@@ -419,7 +414,6 @@ resource "aws_cloudwatch_event_target" "sns_iam_configuration_changes" {
       "EventType"   = "$.detail.eventType"
       "EventTime"   = "$.detail.eventTime"
       "UserAgent"   = "$.detail.userAgent"
-      "AWSRegion"   = "$.detail.awsRegion"
       "EventName"   = "$.detail.eventName"
       "Elements"    = "$.detail.requestParameters[*]"
     }

--- a/events.tf
+++ b/events.tf
@@ -169,7 +169,6 @@ resource "aws_cloudwatch_event_target" "config_compliance_changes" {
     input_paths = {
       "EventTime"           = "$.time"
       "EventType"           = "$.detail-type"
-      "AWSAccount"          = "$.detail.awsAccountId"
       "ConfigRuleName"      = "$.detail.newEvaluationResult.evaluationResultIdentifier.evaluationResultQualifier.configRuleName"
       "ResourceType"        = "$.detail.newEvaluationResult.evaluationResultIdentifier.evaluationResultQualifier.resourceType"
       "ResourceID"          = "$.detail.newEvaluationResult.evaluationResultIdentifier.evaluationResultQualifier.resourceId"
@@ -468,7 +467,6 @@ resource "aws_cloudwatch_event_target" "guardduty_findings" {
       "EventType"   = "$.detail-type"
       "EventSource" = "$.source"
       "AccountID"   = "$.account"
-      "AWSRegion"   = "$.region"
       "Severity"    = "$.detail.severity"
       "Title"       = "$.detail.title"
       "Description" = "$.detail.description"

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
- minimum required Terraform version bumped to v0.13.0
- tflint version bumped to v0.24.1
- Removed AWSAccount and AWSRegion from cloudwatch input_paths
- Fixed module path for tfsec