### PR TITLE
Fix standards subscription ARN

### DIFF
--- a/securityhub.tf
+++ b/securityhub.tf
@@ -3,7 +3,7 @@ resource "aws_securityhub_account" "account" {
 
 resource "aws_securityhub_standards_subscription" "foundations" {
   depends_on    = [aws_securityhub_account.account]
-  standards_arn = "arn:aws:securityhub:::standards/aws-foundational-security-best-practices/v/1.0.0"
+  standards_arn = "arn:aws:securityhub:us-east-1::standards/aws-foundational-security-best-practices/v/1.0.0"
 }
 
 resource "aws_securityhub_standards_subscription" "cis" {


### PR DESCRIPTION
Fixes standards subscription for AWS Foundational best practices according to [Terraform registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/securityhub_standards_subscription)